### PR TITLE
Style checkbox using wrapper div + label

### DIFF
--- a/interfaces/webinterface/css/app.css
+++ b/interfaces/webinterface/css/app.css
@@ -175,14 +175,16 @@ input[type="range"] {
     top: 0;
     z-index: 100;
     left: 0;
-    background: #4aafd3;
+    background: #989898;
     border-width: 0px 0px 2px 0px;
     border-style: solid;
-    border-color: #428ea8;
+    border-color: #818181;
 }
 
 .checkboxWrapper input[type=checkbox]:checked ~ label {
     left: 37px;
+    background: #4aafd3;
+    border-color: #428ea8;
 }
 
 /* Range */

--- a/interfaces/webinterface/css/app.css
+++ b/interfaces/webinterface/css/app.css
@@ -136,39 +136,55 @@ h2 {
 input {
     margin: 0; padding: 0; border: 0;
 }
-input[type="checkbox"], input[type="range"] {
+input[type="range"] {
     border-width: 0px 0px 2px 0px;
     height: 28px;
     border-style: solid;
     margin-top: -2px;
     -webkit-appearance: none;
 }
-/* Switch */
-input[type="checkbox"] {
-    background: #efefef;
-    border-color: #d4d4d4;
-    cursor: pointer;
+
+/* Checkbox */
+.checkboxWrapper
+{
     width: 65px;
-}
-input[type="checkbox"]:after { 
-    display: block;
+    height: 30px;
+    display: inline-block;
+    overflow: hidden;
+    padding: 0;
     position: relative;
-    background: #989898;
-    content: '';
-    height: 26px;
-    width: 28px;
-    border-color: #818181;
+}
+.checkboxWrapper div
+{
+    width: 100%;
+    height:100%;
+    background: #efefef;
+    position: relative;
+    top:-32px;
     border-width: 0px 0px 2px 0px;
     border-style: solid;
+    border-color: #d4d4d4;
 }
-input[type="checkbox"]:checked {
-    padding-left: 40px;
-    padding-right: 0;
-}
-input[type="checkbox"]:checked:after {
+.checkboxWrapper label
+{
+    display: block;
+    width: 28px;
+    height: 28px;
+    cursor: pointer;
+    position: absolute;
+    top: 0;
+    z-index: 100;
+    left: 0;
     background: #4aafd3;
+    border-width: 0px 0px 2px 0px;
+    border-style: solid;
     border-color: #428ea8;
 }
+
+.checkboxWrapper input[type=checkbox]:checked ~ label {
+    left: 37px;
+}
+
 /* Range */
 .rangeWrapper { 
     display: inline-block;

--- a/interfaces/webinterface/index.html
+++ b/interfaces/webinterface/index.html
@@ -119,7 +119,11 @@
       <h2>
         <%= id %>
       </h2>
-      <input type="checkbox" <%= checkedAttribute %>/> 
+      <div class="checkboxWrapper">
+        <input type="checkbox" value="1" id=<%= id %> <%= checkedAttribute %>/>
+        <label for=<%= id %>></label>
+        <div></div>
+      </div>
     </script>
     <script id="text-control-template" type="text/template">
       <h2>


### PR DESCRIPTION
Fixes binarybucks/homA#85
This fixes the styling of checkboxes in Firefox, I've reviewed it in Firefox 37.0.1, Safari 7.1.5, Chrome 42, IE 10 and Chrome and Firefox on Android, all of them work fine.