### PR TITLE
Fix checkbox styling so it can be switched by pressing anywhere on the toggle

### DIFF
--- a/interfaces/webinterface/css/app.css
+++ b/interfaces/webinterface/css/app.css
@@ -145,43 +145,49 @@ input[type="range"] {
 }
 
 /* Checkbox */
+.checkboxWrapper input[type=checkbox]
+{
+    display:none;
+}
+
 .checkboxWrapper
 {
+    display: inline-block;
+    position: relative;
     width: 65px;
     height: 30px;
-    display: inline-block;
     overflow: hidden;
     padding: 0;
-    position: relative;
-}
-.checkboxWrapper div
-{
-    width: 100%;
-    height:100%;
     background: #efefef;
-    position: relative;
-    top:-32px;
-    border-width: 0px 0px 2px 0px;
-    border-style: solid;
-    border-color: #d4d4d4;
+    box-shadow: inset 0 -2px 0 0 #d4d4d4;
 }
 .checkboxWrapper label
 {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height:100%;
+    border-width: 0px 0px 2px 0px;
+    border-style: solid;
+    border-color: #d4d4d4;
+    z-index: 100;
+}
+.checkboxWrapper div
+{
     display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 28px;
     height: 28px;
     cursor: pointer;
-    position: absolute;
-    top: 0;
-    z-index: 100;
-    left: 0;
     background: #989898;
     border-width: 0px 0px 2px 0px;
     border-style: solid;
     border-color: #818181;
 }
-
-.checkboxWrapper input[type=checkbox]:checked ~ label {
+.checkboxWrapper input[type=checkbox]:checked ~ div {
     left: 37px;
     background: #4aafd3;
     border-color: #428ea8;


### PR DESCRIPTION
Allright, that should fix the behaviour of the toggle, Whilst still having the correct styling in firefox :)
Again tested in Firefox 37.0.1, Safari 7.1.5, Chrome 42, IE 10 and Chrome and Firefox on Android, all of them work fine. If anyone finds any issues with this please let me know.

Should fix part of #85 